### PR TITLE
Add basic AppVeyor configuration for MSVC builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# AV1TSU [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/Monteco/AV1TSU?branch=master&svg=true)](https://ci.appveyor.com/project/Monteco/AV1TSU/history)
+FFmpeg and Rav1e interpreter

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,5 @@
+image: Visual Studio 2017
+configuration: Release
+
+build:
+  project: interpreter/interpreter.sln

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,3 +3,7 @@ configuration: Release
 
 build:
   project: interpreter/interpreter.sln
+
+artifacts:
+    - path: bin\Release\*.*
+      name: $(APPVEYOR_PROJECT_NAME)

--- a/interpreter/interpreter/options.cpp
+++ b/interpreter/interpreter/options.cpp
@@ -2,6 +2,7 @@
 #include <fstream>
 #include <string>
 #include "options.h"
+#include "pch.h"
 #include <windows.h>
 using namespace std;
 ofstream out("merge");

--- a/interpreter/interpreter/options.cpp
+++ b/interpreter/interpreter/options.cpp
@@ -2,7 +2,6 @@
 #include <fstream>
 #include <string>
 #include "options.h"
-#include "pch.h"
 #include <windows.h>
 using namespace std;
 ofstream out("merge");


### PR DESCRIPTION
Needs to be enabled on [ci.appveyor.com](https://ci.appveyor.com/project/Monteco/AV1TSU/history) and the [GitHub marketplace](https://github.com/marketplace/appveyor).

See https://ci.appveyor.com/project/EwoutH/av1tsu for example builds. Currently fails on:
```
c:\projects\av1tsu\interpreter\interpreter\options.cpp(105): fatal error C1010: unexpected end of file while looking for precompiled header.
```